### PR TITLE
Pass large worker prompts via stdin

### DIFF
--- a/cairn/src/cairn/dispatcher/runtime/containers.py
+++ b/cairn/src/cairn/dispatcher/runtime/containers.py
@@ -185,6 +185,7 @@ class ContainerManager:
         command: list[str],
         timeout_seconds: int | None = None,
         kill_after_seconds: int = 5,
+        stdin: str | None = None,
     ) -> ManagedProcess:
         container = self._require_container(container_name)
         argv: list[str] = []
@@ -198,7 +199,7 @@ class ContainerManager:
                 ]
             )
         argv.extend(command)
-        return ManagedProcess(container, argv, env)
+        return ManagedProcess(container, argv, env, stdin=stdin)
 
     def remove_container(self, name: str, *, force: bool = True) -> None:
         container = self._get_container(name)

--- a/cairn/src/cairn/dispatcher/runtime/process.py
+++ b/cairn/src/cairn/dispatcher/runtime/process.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 import logging
+import socket
 import threading
 import time
 from typing import Any
@@ -24,9 +26,10 @@ class ProcessResult:
 
 
 class ManagedProcess:
-    def __init__(self, container: Container, command: list[str], env: dict[str, str]):
+    def __init__(self, container: Container, command: list[str], env: dict[str, str], *, stdin: str | None = None):
         self.command = command
         self.env = env
+        self.stdin = stdin
         self._container = container
         self._api = container.client.api
         self._exec_id: str | None = None
@@ -45,12 +48,13 @@ class ManagedProcess:
             self.command,
             stdout=True,
             stderr=True,
-            stdin=False,
+            stdin=self.stdin is not None,
             tty=False,
             environment=self.env,
         )
         self._exec_id = exec_info["Id"]
-        self._reader = threading.Thread(target=self._read_stream, daemon=True)
+        target = self._read_stream if self.stdin is None else self._read_socket_stream
+        self._reader = threading.Thread(target=target, daemon=True)
         self._reader.start()
 
     def communicate(self, timeout: float | None) -> ProcessResult:
@@ -118,6 +122,77 @@ class ManagedProcess:
         finally:
             self._returncode = self._resolve_exit_code()
             self._done.set()
+
+    def _read_socket_stream(self) -> None:
+        assert self._exec_id is not None
+        sock: Any | None = None
+        try:
+            sock = self._api.exec_start(
+                self._exec_id,
+                detach=False,
+                tty=False,
+                socket=True,
+            )
+            self._set_socket_timeout(sock, None)
+            self._send_stdin(sock)
+            self._read_multiplexed_socket(sock)
+        except DockerException as exc:
+            self._read_error = str(exc)
+        except OSError as exc:
+            self._read_error = str(exc)
+        finally:
+            if sock is not None:
+                self._close_socket_response(sock)
+                with suppress(OSError, ValueError):
+                    sock.close()
+            self._returncode = self._resolve_exit_code()
+            self._done.set()
+
+    def _send_stdin(self, sock: Any) -> None:
+        data = (self.stdin or "").encode("utf-8")
+        if data:
+            self._raw_socket(sock).sendall(data)
+        try:
+            self._raw_socket(sock).shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+    def _read_multiplexed_socket(self, sock: Any) -> None:
+        buffer = b""
+        while True:
+            raw_sock = self._raw_socket(sock)
+            chunk = raw_sock.recv(4096)
+            if not chunk:
+                return
+            buffer += chunk
+            while len(buffer) >= 8:
+                stream_type = buffer[0]
+                frame_size = int.from_bytes(buffer[4:8], byteorder="big")
+                if len(buffer) < 8 + frame_size:
+                    break
+                payload = buffer[8 : 8 + frame_size]
+                buffer = buffer[8 + frame_size :]
+                if stream_type == 1:
+                    self._stdout.append(self._decode(payload))
+                elif stream_type == 2:
+                    self._stderr.append(self._decode(payload))
+
+    @staticmethod
+    def _raw_socket(sock: Any) -> Any:
+        return getattr(sock, "_sock", sock)
+
+    @staticmethod
+    def _set_socket_timeout(sock: Any, timeout: float | None) -> None:
+        raw_sock = ManagedProcess._raw_socket(sock)
+        if hasattr(raw_sock, "settimeout"):
+            raw_sock.settimeout(timeout)
+
+    @staticmethod
+    def _close_socket_response(sock: Any) -> None:
+        response = getattr(sock, "_response", None)
+        if response is not None:
+            with suppress(Exception):
+                response.close()
 
     def _resolve_exit_code(self) -> int:
         assert self._exec_id is not None

--- a/cairn/src/cairn/dispatcher/tasks/bootstrap.py
+++ b/cairn/src/cairn/dispatcher/tasks/bootstrap.py
@@ -115,6 +115,7 @@ def run_bootstrap_task(
             timeout_seconds=config.tasks.bootstrap.timeout,
             lease=lease,
             cancellation=cancellation,
+            stdin=execute.stdin,
         )
         execute_ms = int((time.perf_counter() - execute_started) * 1000)
         session = driver.extract_session(session, first.stdout, first.stderr)
@@ -298,18 +299,19 @@ def _try_conclude_fallback(
         load_prompt(config.runtime.prompt_group, "bootstrap_conclude.md"),
         _bootstrap_prompt_replacements(project),
     )
-    conclude_argv = driver.build_conclude(worker, prompt, session)
+    conclude = driver.build_conclude(worker, prompt, session)
     LOG.info("starting bootstrap conclude fallback project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
     conclude_started = time.perf_counter()
     result = run_worker_process(
         container_manager,
         container_name,
         worker,
-        conclude_argv,
+        conclude.argv,
         phase="bootstrap_conclude",
         timeout_seconds=config.tasks.bootstrap.conclude_timeout,
         lease=lease,
         cancellation=cancellation,
+        stdin=conclude.stdin,
     )
     conclude_ms = int((time.perf_counter() - conclude_started) * 1000)
     cancelled = cancel_reason(result, cancellation)

--- a/cairn/src/cairn/dispatcher/tasks/common.py
+++ b/cairn/src/cairn/dispatcher/tasks/common.py
@@ -95,6 +95,7 @@ def run_worker_process(
     timeout_seconds: int,
     lease: HeartbeatLease | None = None,
     cancellation: TaskCancellation | None = None,
+    stdin: str | None = None,
 ) -> ProcessResult:
     LOG.info(
         "starting container exec container=%s worker=%s phase=%s timeout=%ss",
@@ -108,6 +109,7 @@ def run_worker_process(
         dict(worker.env),
         argv,
         timeout_seconds=timeout_seconds,
+        stdin=stdin,
     )
     process.start()
     if lease is not None:

--- a/cairn/src/cairn/dispatcher/tasks/explore.py
+++ b/cairn/src/cairn/dispatcher/tasks/explore.py
@@ -115,6 +115,7 @@ def run_explore_task(
             timeout=config.tasks.explore.timeout,
             lease=lease,
             cancellation=cancellation,
+            stdin=execute.stdin,
         )
         execute_ms = int((time.perf_counter() - execute_started) * 1000)
         session = driver.extract_session(session, first.stdout, first.stderr)
@@ -299,18 +300,19 @@ def _try_conclude_fallback(
             "intent_description": intent.description,
         },
     )
-    conclude_argv = driver.build_conclude(worker, prompt, session)
+    conclude = driver.build_conclude(worker, prompt, session)
     LOG.info("starting conclude fallback project=%s intent=%s worker=%s", project_id, intent.id, worker.name)
     conclude_started = time.perf_counter()
     result = _run_process(
         container_manager,
         container_name,
         worker,
-        conclude_argv,
+        conclude.argv,
         phase="explore_conclude",
         timeout=config.tasks.explore.conclude_timeout,
         lease=lease,
         cancellation=cancellation,
+        stdin=conclude.stdin,
     )
     conclude_ms = int((time.perf_counter() - conclude_started) * 1000)
     cancelled = cancel_reason(result, cancellation)
@@ -391,6 +393,7 @@ def _run_process(
     timeout: int,
     lease: HeartbeatLease,
     cancellation: TaskCancellation,
+    stdin: str | None = None,
 ):
     return run_worker_process(
         container_manager,
@@ -401,4 +404,5 @@ def _run_process(
         timeout_seconds=timeout,
         lease=lease,
         cancellation=cancellation,
+        stdin=stdin,
     )

--- a/cairn/src/cairn/dispatcher/tasks/reason.py
+++ b/cairn/src/cairn/dispatcher/tasks/reason.py
@@ -129,6 +129,7 @@ def run_reason_task(
             timeout_seconds=config.tasks.reason.timeout,
             lease=lease,
             cancellation=cancellation,
+            stdin=command.stdin,
         )
         execute_ms = int((time.perf_counter() - execute_started) * 1000)
         total_ms = int((time.perf_counter() - task_started) * 1000)

--- a/cairn/src/cairn/dispatcher/workers/adapters/claudecode.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/claudecode.py
@@ -81,19 +81,20 @@ class ClaudeCodeDriver(SeedSessionDriver):
                 session,
                 "--dangerously-skip-permissions",
                 "-p",
-                "--",
-                prompt,
             ],
             session=session,
+            stdin=prompt,
         )
 
-    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> list[str]:
-        return [
-            "claude",
-            "-r",
-            session,
-            "--dangerously-skip-permissions",
-            "-p",
-            "--",
-            prompt,
-        ]
+    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> DriverResult:
+        return DriverResult(
+            argv=[
+                "claude",
+                "-r",
+                session,
+                "--dangerously-skip-permissions",
+                "-p",
+            ],
+            session=session,
+            stdin=prompt,
+        )

--- a/cairn/src/cairn/dispatcher/workers/adapters/codex.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/codex.py
@@ -62,35 +62,40 @@ class CodexDriver(RegexSessionDriver):
                 "-c",
                 'model_providers.cairn.env_key="OPENAI_API_KEY"',
                 "--",
-                prompt,
-            ]
+                "-",
+            ],
+            stdin=prompt,
         )
 
-    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> list[str]:
+    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> DriverResult:
         env = worker.env
-        return [
-            "codex",
-            "exec",
-            "resume",
-            session,
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--model",
-            env["CODEX_MODEL"],
-            "-c",
-            'model_provider="cairn"',
-            "-c",
-            'model_providers.cairn.name="cairn"',
-            "-c",
-            'model_providers.cairn.wire_api="responses"',
-            "-c",
-            'model_reasoning_effort="high"',
-            "-c",
-            f'model_providers.cairn.base_url="{env["CODEX_BASE_URL"]}"',
-            "-c",
-            'model_providers.cairn.env_key="OPENAI_API_KEY"',
-            "--",
-            prompt,
-        ]
+        return DriverResult(
+            argv=[
+                "codex",
+                "exec",
+                "resume",
+                session,
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--model",
+                env["CODEX_MODEL"],
+                "-c",
+                'model_provider="cairn"',
+                "-c",
+                'model_providers.cairn.name="cairn"',
+                "-c",
+                'model_providers.cairn.wire_api="responses"',
+                "-c",
+                'model_reasoning_effort="high"',
+                "-c",
+                f'model_providers.cairn.base_url="{env["CODEX_BASE_URL"]}"',
+                "-c",
+                'model_providers.cairn.env_key="OPENAI_API_KEY"',
+                "--",
+                "-",
+            ],
+            session=session,
+            stdin=prompt,
+        )
 
     @staticmethod
     def _healthcheck_url(worker: WorkerConfig) -> str:

--- a/cairn/src/cairn/dispatcher/workers/adapters/mock.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/mock.py
@@ -134,5 +134,5 @@ class MockDriver(SeedSessionDriver):
     def build_execute(self, worker: WorkerConfig, prompt: str, session: str | None) -> DriverResult:
         return DriverResult(argv=self._argv(worker, prompt), session=session)
 
-    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> list[str]:
-        return self._argv(worker, prompt)
+    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> DriverResult:
+        return DriverResult(argv=self._argv(worker, prompt), session=session)

--- a/cairn/src/cairn/dispatcher/workers/adapters/pi.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/pi.py
@@ -49,7 +49,7 @@ class PiDriver(WorkerDriver):
         argv.extend(["-p", prompt])
         return DriverResult(argv=self._wrap_with_models(worker, argv), session=session)
 
-    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> list[str]:
+    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> DriverResult:
         env = worker.env
         argv = [
             "--provider",
@@ -65,7 +65,7 @@ class PiDriver(WorkerDriver):
             "-p",
             prompt,
         ]
-        return self._wrap_with_models(worker, argv)
+        return DriverResult(argv=self._wrap_with_models(worker, argv), session=session)
 
     def extract_session(self, session: str | None, stdout: str, stderr: str) -> str | None:
         if session:

--- a/cairn/src/cairn/dispatcher/workers/base.py
+++ b/cairn/src/cairn/dispatcher/workers/base.py
@@ -13,6 +13,7 @@ from cairn.dispatcher.config import WorkerConfig
 class DriverResult:
     argv: list[str]
     session: str | None = None
+    stdin: str | None = None
 
 
 class WorkerDriver(abc.ABC):
@@ -39,7 +40,7 @@ class WorkerDriver(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> list[str]:
+    def build_conclude(self, worker: WorkerConfig, prompt: str, session: str) -> DriverResult:
         raise NotImplementedError
 
     def extract_session(self, session: str | None, stdout: str, stderr: str) -> str | None:


### PR DESCRIPTION
## Problem

When a project graph grows large, worker prompts can exceed the OS argument-size limit before the worker CLI starts. In a real dispatcher run, a large `reason` prompt failed repeatedly with:

```text
exec /usr/bin/timeout: argument list too long
```

The command shape was effectively:

```text
timeout -k 5s 300s claude ... -p -- <large prompt>
```

On Linux, the total `ARG_MAX` may be around 2 MiB, but a single argument is typically capped around 128 KiB. A graph YAML prompt can hit the single-argument limit first.

## Fix

This PR adds stdin support to the managed Docker exec path and moves large prompts out of argv for worker drivers that support stdin.

- Add optional `stdin` to `DriverResult`.
- Add stdin support to `ManagedProcess` / `ContainerManager`.
- Pass prompts through stdin for `claudecode` and `codex`.
- Keep timeout wrapping and heartbeat/cancellation behavior intact.
- Update conclude call sites to carry `DriverResult` instead of raw argv.

## Verification

- `uv run python -m compileall src/cairn`
- `git diff --check -- cairn/src/cairn/dispatcher`
- Manual Docker exec stdin regression: passed a 300000-byte payload through stdin and read it successfully inside the worker container.
- Restarted the local dispatcher after rebuilding `cairn-app`; the previous `argument list too long` failure disappeared.

## Notes

This does not solve separate large-context or model-timeout concerns. It only fixes prompt transport so large prompts do not fail at `execve` before the worker starts.
