### PR TITLE
feat: add Ruff, Pyright and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev-*]
+  pull_request:
+    branches: [main, dev-*]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cairn
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Ruff check
+        run: uv run ruff check src/
+
+      - name: Ruff format
+        run: uv run ruff format --check src/
+
+      - name: Pyright
+        run: uv run pyright src/
+
+      - name: Tests
+        run: uv run pytest

--- a/cairn/pyproject.toml
+++ b/cairn/pyproject.toml
@@ -26,10 +26,50 @@ build-backend = "uv_build"
 dev = [
     "httpx>=0.27",
     "pytest>=8.3",
+    "ruff>=0.12",
+    "pyright>=1.1",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "N",      # pep8-naming
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "S",      # flake8-bandit (security)
+    "A",      # flake8-builtins
+    "T20",    # flake8-print
+    "SIM",    # flake8-simplify
+    "RUF",    # ruff-specific
+]
+ignore = [
+    "E501",   # line too long — log/SQL lines are fine
+    "S101",   # assert used — tests need it
+    "S108",   # hardcoded tmp path — intentional container paths
+    "S311",   # pseudo-random — used for load balancing, not crypto
+    "S603",   # subprocess without shell=True — intentional
+    "S607",   # partial executable path — intentional
+    "A002",   # shadowing builtin — query param naming
+    "SIM108", # ternary — readability preference
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["cairn"]
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "basic"
+include = ["src"]
 
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"

--- a/cairn/src/cairn/dispatcher/config.py
+++ b/cairn/src/cairn/dispatcher/config.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from decimal import Decimal, InvalidOperation
 import json
+from decimal import Decimal, InvalidOperation
 from importlib import resources
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-
 
 TaskType = Literal["reason", "explore", "bootstrap"]
 WorkerType = Literal["claudecode", "codex", "pi", "mock"]
@@ -122,9 +121,7 @@ MOCK_DEFAULT_BEHAVIOR: dict[str, dict[str, Any]] = {
     },
 }
 
-MOCK_ALLOWED_ENV_KEYS = frozenset(
-    {f"MOCK_{phase.upper()}" for phase in MOCK_ALLOWED_OUTCOMES}
-)
+MOCK_ALLOWED_ENV_KEYS = frozenset({f"MOCK_{phase.upper()}" for phase in MOCK_ALLOWED_OUTCOMES})
 
 
 class ReasonTaskConfig(BaseModel):
@@ -185,7 +182,7 @@ class WorkerConfig(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def validate_env(self) -> "WorkerConfig":
+    def validate_env(self) -> WorkerConfig:
         required = WORKER_ENV_KEYS[self.type]
         missing = [key for key in required if not self.env.get(key)]
         if missing:
@@ -238,7 +235,7 @@ class DispatchConfig(BaseModel):
         return merged
 
     @model_validator(mode="after")
-    def validate_workers(self) -> "DispatchConfig":
+    def validate_workers(self) -> DispatchConfig:
         names = [worker.name for worker in self.workers]
         if len(set(names)) != len(names):
             raise ValueError("worker names must be unique")
@@ -249,7 +246,7 @@ class DispatchConfig(BaseModel):
         return self
 
     @classmethod
-    def load(cls, path: Path) -> "DispatchConfig":
+    def load(cls, path: Path) -> DispatchConfig:
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         config = cls.model_validate(data)
         validate_prompt_resources(config.runtime.prompt_group)
@@ -301,7 +298,9 @@ def resolve_mock_behavior(worker_name: str, env: dict[str, str]) -> dict[str, di
             raise ValueError(f"worker {worker_name} {prefix}.outcomes must be an object")
         unknown_outcomes = sorted(set(raw_outcomes) - allowed_outcomes)
         if unknown_outcomes:
-            raise ValueError(f"worker {worker_name} {prefix}.outcomes has unsupported keys: {', '.join(unknown_outcomes)}")
+            raise ValueError(
+                f"worker {worker_name} {prefix}.outcomes has unsupported keys: {', '.join(unknown_outcomes)}"
+            )
         outcomes: dict[str, float] = {}
         total = Decimal("0")
         for outcome in sorted(allowed_outcomes):
@@ -336,17 +335,23 @@ def resolve_mock_behavior(worker_name: str, env: dict[str, str]) -> dict[str, di
                 if "fact_ids_gte" in rule:
                     value = rule["fact_ids_gte"]
                     if not isinstance(value, int) or value < 0:
-                        raise ValueError(f"worker {worker_name} {prefix}.rules[{index}].fact_ids_gte must be a non-negative integer")
+                        raise ValueError(
+                            f"worker {worker_name} {prefix}.rules[{index}].fact_ids_gte must be a non-negative integer"
+                        )
                     entry["fact_ids_gte"] = value
                 if "fact_ids_lte" in rule:
                     value = rule["fact_ids_lte"]
                     if not isinstance(value, int) or value < 0:
-                        raise ValueError(f"worker {worker_name} {prefix}.rules[{index}].fact_ids_lte must be a non-negative integer")
+                        raise ValueError(
+                            f"worker {worker_name} {prefix}.rules[{index}].fact_ids_lte must be a non-negative integer"
+                        )
                     entry["fact_ids_lte"] = value
                 if "open_intents_empty" in rule:
                     value = rule["open_intents_empty"]
                     if not isinstance(value, bool):
-                        raise ValueError(f"worker {worker_name} {prefix}.rules[{index}].open_intents_empty must be boolean")
+                        raise ValueError(
+                            f"worker {worker_name} {prefix}.rules[{index}].open_intents_empty must be boolean"
+                        )
                     entry["open_intents_empty"] = value
                 normalized_rules.append(entry)
             behavior[phase]["rules"] = normalized_rules
@@ -357,7 +362,9 @@ def _mock_env_prefix(phase: str) -> str:
     return f"MOCK_{phase.upper()}"
 
 
-def _parse_mock_phase_payload(worker_name: str, env: dict[str, str], key: str, default: dict[str, Any]) -> dict[str, Any]:
+def _parse_mock_phase_payload(
+    worker_name: str, env: dict[str, str], key: str, default: dict[str, Any]
+) -> dict[str, Any]:
     raw = env.get(key)
     if raw is None:
         return json.loads(json.dumps(default))

--- a/cairn/src/cairn/dispatcher/contracts.py
+++ b/cairn/src/cairn/dispatcher/contracts.py
@@ -60,7 +60,9 @@ def _looks_like_explore_data(payload: dict[str, Any]) -> bool:
 
 
 def validate_reason_payload(
-    payload: dict[str, Any], open_intents_empty: bool, max_intents: int,
+    payload: dict[str, Any],
+    open_intents_empty: bool,
+    max_intents: int,
 ) -> tuple[str, dict[str, Any] | list[dict[str, Any]] | None]:
     accepted, data = _unwrap_wrapped_payload(payload)
     if accepted is False:

--- a/cairn/src/cairn/dispatcher/logging.py
+++ b/cairn/src/cairn/dispatcher/logging.py
@@ -9,10 +9,10 @@ class DispatcherLogFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         name = record.name
         if name.startswith(self._PREFIX):
-            shortname = name[len(self._PREFIX):]
+            shortname = name[len(self._PREFIX) :]
         else:
             shortname = name
-        setattr(record, "shortname", shortname)
+        record.shortname = shortname
         return super().format(record)
 
 

--- a/cairn/src/cairn/dispatcher/output_parser.py
+++ b/cairn/src/cairn/dispatcher/output_parser.py
@@ -4,7 +4,6 @@ import json
 import re
 from typing import Any
 
-
 FENCED_BLOCK_RE = re.compile(r"```(?:json)?\s*\n?(.*?)```", re.IGNORECASE | re.DOTALL)
 
 

--- a/cairn/src/cairn/dispatcher/protocol/client.py
+++ b/cairn/src/cairn/dispatcher/protocol/client.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
 import logging
 import threading
+from dataclasses import dataclass
+from typing import Any
 
-from pydantic import TypeAdapter
 import requests
+from pydantic import TypeAdapter
 from requests.adapters import HTTPAdapter
 
-from cairn.server.models import Intent, ProjectDetail, ProjectSummary, Settings
+from cairn.server.models import ProjectDetail, ProjectSummary, Settings
 
 LOG = logging.getLogger(__name__)
 

--- a/cairn/src/cairn/dispatcher/runtime/containers.py
+++ b/cairn/src/cairn/dispatcher/runtime/containers.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import io
 import logging
-from pathlib import PurePosixPath
 import tarfile
 import threading
 import uuid
+from pathlib import PurePosixPath
 
 import docker
 from docker.errors import APIError, DockerException, NotFound
@@ -173,7 +173,9 @@ class ContainerManager:
         except DockerException as exc:
             LOG.warning("failed to list managed containers error=%s", exc)
             return []
-        return sorted(container.name for container in containers if container.name.startswith(self._PREFIX))
+        return sorted(
+            container.name for container in containers if container.name and container.name.startswith(self._PREFIX)
+        )
 
     def needs_completed_cleanup(self, project_id: str) -> bool:
         name = self.container_name(project_id)

--- a/cairn/src/cairn/dispatcher/runtime/heartbeat.py
+++ b/cairn/src/cairn/dispatcher/runtime/heartbeat.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from cairn.dispatcher.protocol.client import ApiResult, CairnClient
 from cairn.dispatcher.runtime.process import ManagedProcess
 
-
 LOG = logging.getLogger(__name__)
 HEARTBEAT_FAILURE_GRACE_MULTIPLIER = 2
 
@@ -47,7 +46,7 @@ class HeartbeatLease:
         intent_id: str,
         worker_name: str,
         interval: int,
-    ) -> "HeartbeatLease":
+    ) -> HeartbeatLease:
         return cls(
             heartbeat=lambda: client.heartbeat(project_id, intent_id, worker_name),
             scope=f"project={project_id} intent={intent_id}",
@@ -62,7 +61,7 @@ class HeartbeatLease:
         project_id: str,
         worker_name: str,
         interval: int,
-    ) -> "HeartbeatLease":
+    ) -> HeartbeatLease:
         return cls(
             heartbeat=lambda: client.reason_heartbeat(project_id, worker_name),
             scope=f"project={project_id} reason",

--- a/cairn/src/cairn/dispatcher/runtime/process.py
+++ b/cairn/src/cairn/dispatcher/runtime/process.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from contextlib import suppress
-from dataclasses import dataclass
 import logging
 import threading
 import time
+from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any
 
 from docker.errors import APIError, DockerException
@@ -29,7 +29,7 @@ class ManagedProcess:
         self.command = command
         self.env = env
         self._container = container
-        self._api = container.client.api
+        self._api = container.client.api  # type: ignore[union-attr]
         self._exec_id: str | None = None
         self._reader: threading.Thread | None = None
         self._stdout: list[str] = []
@@ -169,7 +169,9 @@ class ManagedProcess:
             if exit_code in (None, 0, 1):
                 return
         if last_error is not None:
-            LOG.warning("failed to kill container exec pid=%s container=%s error=%s", pid, self._container.name, last_error)
+            LOG.warning(
+                "failed to kill container exec pid=%s container=%s error=%s", pid, self._container.name, last_error
+            )
 
     @staticmethod
     def _split_chunk(chunk: Any) -> tuple[str, str]:

--- a/cairn/src/cairn/dispatcher/runtime/startup_healthcheck.py
+++ b/cairn/src/cairn/dispatcher/runtime/startup_healthcheck.py
@@ -143,9 +143,7 @@ def _log_report(results: list[StartupHealthcheckResult], *, show_commands: bool)
             f"{duration_seconds:>8}  "
             f"{preview}"
         )
-    lines.append(
-        f"[=] Summary: total={len(results)} healthy={healthy_count} unhealthy={len(results) - healthy_count}"
-    )
+    lines.append(f"[=] Summary: total={len(results)} healthy={healthy_count} unhealthy={len(results) - healthy_count}")
     if show_commands:
         lines.append("")
         lines.append("[=] Startup healthcheck commands")

--- a/cairn/src/cairn/dispatcher/scheduler/loop.py
+++ b/cairn/src/cairn/dispatcher/scheduler/loop.py
@@ -405,10 +405,17 @@ class DispatcherLoop:
                 cancellation := TaskCancellation(),
             )
         except Exception:
-            LOG.exception("failed to submit bootstrap task project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
+            LOG.exception(
+                "failed to submit bootstrap task project=%s intent=%s worker=%s",
+                project.project.id,
+                intent.id,
+                worker.name,
+            )
             self._best_effort_release(project.project.id, intent.id, worker.name)
             return False
-        self.futures[future] = RunningTask(project.project.id, "bootstrap", worker.name, cancellation, intent_id=intent.id)
+        self.futures[future] = RunningTask(
+            project.project.id, "bootstrap", worker.name, cancellation, intent_id=intent.id
+        )
         self.runtime_project_ids.add(project.project.id)
         self._clear_project_log_state(project.project.id)
         LOG.info("dispatched bootstrap project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
@@ -464,10 +471,17 @@ class DispatcherLoop:
                 cancellation := TaskCancellation(),
             )
         except Exception:
-            LOG.exception("failed to submit explore task project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
+            LOG.exception(
+                "failed to submit explore task project=%s intent=%s worker=%s",
+                project.project.id,
+                intent.id,
+                worker.name,
+            )
             self._best_effort_release(project.project.id, intent.id, worker.name)
             return False
-        self.futures[future] = RunningTask(project.project.id, "explore", worker.name, cancellation, intent_id=intent.id)
+        self.futures[future] = RunningTask(
+            project.project.id, "explore", worker.name, cancellation, intent_id=intent.id
+        )
         self.runtime_project_ids.add(project.project.id)
         self._clear_project_log_state(project.project.id)
         LOG.info("dispatched explore project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
@@ -520,7 +534,10 @@ class DispatcherLoop:
             "worker selection project=%s task=%s candidates=%s blocked_busy=%s blocked_unhealthy=%s blocked_rejected=%s blocked_task_type=%s chosen=%s",
             project_id,
             task_type,
-            [f"{worker.name}({running_counts.get(worker.name, 0)}/{worker.max_running},p{worker.priority})" for worker in candidates],
+            [
+                f"{worker.name}({running_counts.get(worker.name, 0)}/{worker.max_running},p{worker.priority})"
+                for worker in candidates
+            ],
             blocked_busy,
             blocked_unhealthy,
             blocked_rejected,
@@ -586,7 +603,11 @@ class DispatcherLoop:
         if not intents:
             return None
         if len(intents) > 1:
-            LOG.warning("project has multiple bootstrap intents project=%s intents=%s", project.project.id, [intent.id for intent in intents])
+            LOG.warning(
+                "project has multiple bootstrap intents project=%s intents=%s",
+                project.project.id,
+                [intent.id for intent in intents],
+            )
         intents.sort(key=lambda intent: (intent.worker is not None, intent.created_at, intent.id))
         return intents[0]
 
@@ -708,7 +729,9 @@ class DispatcherLoop:
                         task.open_intent_count,
                     )
             except Exception:
-                LOG.exception("task crashed project=%s task=%s worker=%s", task.project_id, task.task_type, task.worker_name)
+                LOG.exception(
+                    "task crashed project=%s task=%s worker=%s", task.project_id, task.task_type, task.worker_name
+                )
 
     def _cleanup_completed_containers(self, summaries: list[ProjectSummary]) -> None:
         for summary in summaries:
@@ -809,12 +832,20 @@ class DispatcherLoop:
     def _best_effort_release(self, project_id: str, intent_id: str, worker_name: str) -> None:
         response = self.client.release(project_id, intent_id, worker_name)
         if not response.ok and response.status_code not in (403, 409):
-            LOG.warning("release failed project=%s intent=%s worker=%s status=%s", project_id, intent_id, worker_name, response.status_code)
+            LOG.warning(
+                "release failed project=%s intent=%s worker=%s status=%s",
+                project_id,
+                intent_id,
+                worker_name,
+                response.status_code,
+            )
 
     def _best_effort_release_reason(self, project_id: str, worker_name: str) -> None:
         response = self.client.release_reason(project_id, worker_name)
         if not response.ok and response.status_code not in (403, 409):
-            LOG.warning("reason release failed project=%s worker=%s status=%s", project_id, worker_name, response.status_code)
+            LOG.warning(
+                "reason release failed project=%s worker=%s status=%s", project_id, worker_name, response.status_code
+            )
 
     def _log_changed(self, scope: str, level: int, message: str, *args: object) -> None:
         state = (level, message, args)
@@ -837,9 +868,7 @@ class DispatcherLoop:
         interval = self.config.runtime.interval
         for name, value in (("intent_timeout", settings.intent_timeout), ("reason_timeout", settings.reason_timeout)):
             if value <= interval:
-                raise RuntimeError(
-                    f"server {name}={value}s must be greater than dispatcher interval={interval}s"
-                )
+                raise RuntimeError(f"server {name}={value}s must be greater than dispatcher interval={interval}s")
             if value < interval * 2:
                 LOG.warning(
                     "server %s is tight %s=%ss interval=%ss; heartbeat slack is only %ss",

--- a/cairn/src/cairn/dispatcher/tasks/bootstrap.py
+++ b/cairn/src/cairn/dispatcher/tasks/bootstrap.py
@@ -18,8 +18,8 @@ from cairn.dispatcher.tasks.common import (
     best_effort_release,
     cancel_reason,
     did_timeout,
-    project_allows_conclude_fallback,
     preview,
+    project_allows_conclude_fallback,
     run_healthcheck,
     run_worker_process,
     task_healthcheck_enabled,
@@ -173,7 +173,7 @@ def run_bootstrap_task(
                     lease,
                     cancellation,
                 )
-            if kind == "rejected":
+            if kind == "rejected" or data is None:
                 LOG.warning(
                     "bootstrap rejected project=%s intent=%s worker=%s execute_ms=%s total_ms=%s stdout_preview=%s",
                     project.project.id,
@@ -234,7 +234,9 @@ def run_bootstrap_task(
         best_effort_release(client, project.project.id, intent.id, worker.name)
         return "failed"
     except Exception:
-        LOG.exception("bootstrap task crashed project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
+        LOG.exception(
+            "bootstrap task crashed project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name
+        )
         best_effort_release(client, project.project.id, intent.id, worker.name)
         return "failed"
     finally:
@@ -301,7 +303,12 @@ def _try_conclude_fallback(
         _bootstrap_prompt_replacements(project),
     )
     conclude_argv = driver.build_conclude(worker, prompt, session)
-    LOG.info("starting bootstrap conclude fallback project=%s intent=%s worker=%s", project.project.id, intent.id, worker.name)
+    LOG.info(
+        "starting bootstrap conclude fallback project=%s intent=%s worker=%s",
+        project.project.id,
+        intent.id,
+        worker.name,
+    )
     conclude_started = time.perf_counter()
     result = run_worker_process(
         container_manager,
@@ -385,7 +392,7 @@ def _try_conclude_fallback(
         project.project.id,
         intent.id,
         worker.name,
-        fact_description,
+        fact_description or "",
         source="bootstrap_conclude",
         phase_ms=conclude_ms,
     )

--- a/cairn/src/cairn/dispatcher/tasks/common.py
+++ b/cairn/src/cairn/dispatcher/tasks/common.py
@@ -98,7 +98,9 @@ def run_healthcheck(
         cancellation.attach_process(process)
     started = time.perf_counter()
     try:
-        result = process.communicate(timeout=communicate_timeout(timeout_seconds, HEALTHCHECK_COMMUNICATE_GRACE_SECONDS))
+        result = process.communicate(
+            timeout=communicate_timeout(timeout_seconds, HEALTHCHECK_COMMUNICATE_GRACE_SECONDS)
+        )
     finally:
         if lease is not None:
             lease.attach_process(None)

--- a/cairn/src/cairn/dispatcher/tasks/explore.py
+++ b/cairn/src/cairn/dispatcher/tasks/explore.py
@@ -14,8 +14,8 @@ from cairn.dispatcher.tasks.common import (
     best_effort_release,
     cancel_reason,
     did_timeout,
-    project_allows_conclude_fallback,
     preview,
+    project_allows_conclude_fallback,
     run_healthcheck,
     run_worker_process,
     task_healthcheck_enabled,
@@ -197,7 +197,7 @@ def run_explore_task(
                 project.project.id,
                 intent.id,
                 worker.name,
-                description,
+                description or "",
                 source="explore_execute",
                 phase_ms=execute_ms,
                 total_ms=int((time.perf_counter() - task_started) * 1000),
@@ -274,7 +274,12 @@ def _try_conclude_fallback(
         best_effort_release(client, project_id, intent.id, worker.name)
         return "failed"
     if lease.failure is not None:
-        LOG.warning("conclude fallback skipped because heartbeat already lost project=%s intent=%s worker=%s", project_id, intent.id, worker.name)
+        LOG.warning(
+            "conclude fallback skipped because heartbeat already lost project=%s intent=%s worker=%s",
+            project_id,
+            intent.id,
+            worker.name,
+        )
         best_effort_release(client, project_id, intent.id, worker.name)
         return "failed"
     if cancellation.is_cancelled:
@@ -388,7 +393,7 @@ def _try_conclude_fallback(
         project_id,
         intent.id,
         worker.name,
-        description,
+        description or "",
         source="explore_conclude",
         phase_ms=conclude_ms,
     )

--- a/cairn/src/cairn/dispatcher/tasks/reason.py
+++ b/cairn/src/cairn/dispatcher/tasks/reason.py
@@ -187,7 +187,9 @@ def run_reason_task(
             model_output = driver.extract_response_text(result.stdout, result.stderr)
             payload = parse_json_output(model_output)
             kind, data = validate_reason_payload(
-                payload, open_intents_empty=not open_intents, max_intents=config.tasks.reason.max_intents,
+                payload,
+                open_intents_empty=not open_intents,
+                max_intents=config.tasks.reason.max_intents,
             )
         except Exception as exc:
             LOG.warning(
@@ -212,9 +214,14 @@ def run_reason_task(
             )
             return "rejected"
         if kind == "complete":
+            assert isinstance(data, dict)
             response = client.complete(project.project.id, data["from"], data["description"], worker.name)
             if response.status_code == 403:
-                LOG.info("project became inactive during reason complete project=%s worker=%s", project.project.id, worker.name)
+                LOG.info(
+                    "project became inactive during reason complete project=%s worker=%s",
+                    project.project.id,
+                    worker.name,
+                )
                 return "success"
             if not response.ok:
                 LOG.warning(
@@ -235,14 +242,27 @@ def run_reason_task(
             )
             return "success"
         if kind == "intents":
+            assert isinstance(data, list)
             created = 0
             for intent_data in data:
-                response = client.create_intent(project.project.id, intent_data["from"], intent_data["description"], worker.name)
+                response = client.create_intent(
+                    project.project.id, intent_data["from"], intent_data["description"], worker.name
+                )
                 if response.status_code == 403:
-                    LOG.info("project became inactive during reason intent create project=%s worker=%s created=%s", project.project.id, worker.name, created)
+                    LOG.info(
+                        "project became inactive during reason intent create project=%s worker=%s created=%s",
+                        project.project.id,
+                        worker.name,
+                        created,
+                    )
                     return "success"
                 if response.status_code == 409:
-                    LOG.info("reason intent lost race project=%s worker=%s from=%s", project.project.id, worker.name, intent_data["from"])
+                    LOG.info(
+                        "reason intent lost race project=%s worker=%s from=%s",
+                        project.project.id,
+                        worker.name,
+                        intent_data["from"],
+                    )
                     continue
                 if not response.ok:
                     LOG.warning(

--- a/cairn/src/cairn/dispatcher/workers/adapters/__init__.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/__init__.py
@@ -3,4 +3,4 @@ from cairn.dispatcher.workers.adapters.codex import CodexDriver
 from cairn.dispatcher.workers.adapters.mock import MockDriver
 from cairn.dispatcher.workers.adapters.pi import PiDriver
 
-__all__ = ["ClaudeCodeDriver", "CodexDriver", "PiDriver", "MockDriver"]
+__all__ = ["ClaudeCodeDriver", "CodexDriver", "MockDriver", "PiDriver"]

--- a/cairn/src/cairn/dispatcher/workers/adapters/_curl.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/_curl.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass
 
-
 _VERBOSE_CURL_SCRIPT = """
 url="$1"
 payload="$2"

--- a/cairn/src/cairn/dispatcher/workers/adapters/claudecode.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/claudecode.py
@@ -4,7 +4,6 @@ from cairn.dispatcher.config import WorkerConfig
 from cairn.dispatcher.workers.adapters._curl import build_verbose_curl_healthcheck, expand_env, render_curl_command
 from cairn.dispatcher.workers.base import DriverResult, SeedSessionDriver
 
-
 ANTHROPIC_VERSION = "2023-06-01"
 
 

--- a/cairn/src/cairn/dispatcher/workers/adapters/codex.py
+++ b/cairn/src/cairn/dispatcher/workers/adapters/codex.py
@@ -107,9 +107,4 @@ class CodexDriver(RegexSessionDriver):
 
     @staticmethod
     def _healthcheck_payload(worker: WorkerConfig) -> str:
-        return (
-            '{"input":[{"content":"ping","role":"user"}],'
-            '"model":"'
-            + worker.env["CODEX_MODEL"]
-            + '","stream":false}'
-        )
+        return '{"input":[{"content":"ping","role":"user"}],"model":"' + worker.env["CODEX_MODEL"] + '","stream":false}'

--- a/cairn/src/cairn/dispatcher/workers/registry.py
+++ b/cairn/src/cairn/dispatcher/workers/registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from cairn.dispatcher.workers.adapters import ClaudeCodeDriver, CodexDriver, MockDriver, PiDriver
 from cairn.dispatcher.workers.base import WorkerDriver
 
-
 DRIVERS: dict[str, WorkerDriver] = {
     "claudecode": ClaudeCodeDriver(),
     "codex": CodexDriver(),

--- a/cairn/src/cairn/server/db.py
+++ b/cairn/src/cairn/server/db.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
 
 DEFAULT_DB = Path.home() / ".local" / "share" / "cairn" / "cairn.db"
 

--- a/cairn/src/cairn/server/routers/export.py
+++ b/cairn/src/cairn/server/routers/export.py
@@ -1,7 +1,8 @@
+from datetime import datetime
+
+import yaml
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
-from datetime import datetime
-import yaml
 
 from cairn.server.db import get_conn
 from cairn.server.services import expire_reason_leases, expire_workers, get_project_or_404
@@ -24,9 +25,7 @@ def _load_project_data(conn, project_id: str):
     expire_reason_leases(conn, project_id)
     proj = get_project_or_404(conn, project_id)
 
-    facts = conn.execute(
-        "SELECT id, description FROM facts WHERE project_id = ?", (project_id,)
-    ).fetchall()
+    facts = conn.execute("SELECT id, description FROM facts WHERE project_id = ?", (project_id,)).fetchall()
     hints = conn.execute(
         "SELECT content, creator, created_at FROM hints WHERE project_id = ? ORDER BY created_at",
         (project_id,),

--- a/cairn/src/cairn/server/routers/intents.py
+++ b/cairn/src/cairn/server/routers/intents.py
@@ -18,8 +18,8 @@ from cairn.server.services import (
     next_intent_id,
     utcnow,
     validate_facts_exist,
-    validate_intent_creator_worker,
     validate_goal_not_in_sources,
+    validate_intent_creator_worker,
 )
 
 router = APIRouter(tags=["intents"])

--- a/cairn/src/cairn/server/routers/projects.py
+++ b/cairn/src/cairn/server/routers/projects.py
@@ -5,22 +5,22 @@ from cairn.server.models import (
     CompleteRequest,
     CreateProjectRequest,
     Fact,
-    Hint,
     HeartbeatRequest,
+    Hint,
     Intent,
     ProjectDetail,
     ProjectMeta,
     ProjectSummary,
+    ReasonClaimRequest,
     ReopenRequest,
     ReopenResponse,
-    ReasonClaimRequest,
-    UpdateProjectTitleRequest,
     UpdateProjectStatusRequest,
+    UpdateProjectTitleRequest,
 )
 from cairn.server.services import (
     build_intents,
-    check_project_completed,
     check_project_active,
+    check_project_completed,
     clear_project_reason,
     expire_reason_leases,
     expire_workers,
@@ -128,9 +128,7 @@ def get_project(project_id: str):
         expire_reason_leases(conn, project_id)
         row = get_project_or_404(conn, project_id)
 
-        facts = conn.execute(
-            "SELECT * FROM facts WHERE project_id = ?", (project_id,)
-        ).fetchall()
+        facts = conn.execute("SELECT * FROM facts WHERE project_id = ?", (project_id,)).fetchall()
         hints = conn.execute(
             "SELECT * FROM hints WHERE project_id = ? ORDER BY created_at",
             (project_id,),

--- a/cairn/src/cairn/server/services.py
+++ b/cairn/src/cairn/server/services.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import HTTPException
 
 from cairn.server.models import Intent, ProjectMeta, ProjectReason
 
+
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def next_project_id(conn: sqlite3.Connection) -> str:
@@ -17,9 +18,7 @@ def next_project_id(conn: sqlite3.Connection) -> str:
     return f"proj_{row['value']:03d}"
 
 
-def _next_scoped_id(
-    conn: sqlite3.Connection, kind: str, prefix: str, project_id: str
-) -> str:
+def _next_scoped_id(conn: sqlite3.Connection, kind: str, prefix: str, project_id: str) -> str:
     conn.execute(
         "INSERT OR IGNORE INTO scoped_counters (project_id, kind, value) VALUES (?, ?, 0)",
         (project_id, kind),
@@ -76,13 +75,9 @@ def check_project_completed(conn: sqlite3.Connection, project_id: str) -> sqlite
     return row
 
 
-def validate_facts_exist(
-    conn: sqlite3.Connection, project_id: str, fact_ids: list[str]
-) -> None:
+def validate_facts_exist(conn: sqlite3.Connection, project_id: str, fact_ids: list[str]) -> None:
     for fid in fact_ids:
-        row = conn.execute(
-            "SELECT 1 FROM facts WHERE id = ? AND project_id = ?", (fid, project_id)
-        ).fetchone()
+        row = conn.execute("SELECT 1 FROM facts WHERE id = ? AND project_id = ?", (fid, project_id)).fetchone()
         if row is None:
             raise HTTPException(404, f"Fact {fid} not found")
 
@@ -97,9 +92,7 @@ def validate_intent_creator_worker(creator: str, worker: str | None) -> None:
         raise HTTPException(400, "worker must be null or equal to creator")
 
 
-def get_intent_or_404(
-    conn: sqlite3.Connection, project_id: str, intent_id: str
-) -> sqlite3.Row:
+def get_intent_or_404(conn: sqlite3.Connection, project_id: str, intent_id: str) -> sqlite3.Row:
     row = conn.execute(
         "SELECT * FROM intents WHERE id = ? AND project_id = ?",
         (intent_id, project_id),

--- a/cairn/uv.lock
+++ b/cairn/uv.lock
@@ -49,7 +49,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pyright" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -65,7 +67,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=8.3" },
+    { name = "ruff", specifier = ">=0.12" },
 ]
 
 [[package]]
@@ -286,6 +290,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -399,6 +412,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -498,6 +524,31 @@ dependencies = [
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add **Ruff** (lint + format) and **Pyright** (type check) as dev dependencies
- Configure Ruff with 12 rule groups (pycodestyle, pyflakes, isort, pep8-naming, pyupgrade, flake8-bugbear, flake8-bandit, flake8-builtins, flake8-print, flake8-simplify, ruff-specific) and project-specific ignores
- Configure Pyright in basic mode targeting Python 3.12
- Auto-fix 28 lint issues (import sorting, quoted annotations, etc.) and reformat 14 files
- Fix all 26 Pyright type errors (Optional type narrowing, type guards, union-attr)
- Add GitHub Actions CI workflow (`ci.yml`) running `ruff check`, `ruff format --check`, `pyright`, and `pytest` on push/PR to `main` and `dev-*` branches

## Test plan

- [x] `uv run ruff check src/` — All checks passed
- [x] `uv run ruff format --check src/` — 40 files already formatted
- [x] `uv run pyright src/` — 0 errors, 0 warnings
- [x] `uv run pytest` — 61 passed
- [ ] Verify CI workflow runs on this PR