### PR TITLE
feat: add bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: "Bug Report / 缺陷报告"
+description: "Report a bug or unexpected behavior / 报告缺陷或异常行为"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting! Please fill in the sections below.
+        感谢反馈！请填写以下内容。
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Component / 组件"
+      description: "Which part of Cairn is affected? / 哪个部分受到影响？"
+      options:
+        - "Server (API / Web UI)"
+        - "Dispatcher (Scheduler / Tasks)"
+        - "Worker (Claude Code / Codex / Pi)"
+        - "Container / Docker"
+        - "Other / 其他"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description / 描述"
+      description: "A clear description of the bug. / 清晰描述该缺陷。"
+      placeholder: |
+        What happened? What did you expect?
+        发生了什么？你期望的行为是什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to Reproduce / 复现步骤"
+      description: "Minimal steps to reproduce the issue. / 最小化复现步骤。"
+      placeholder: |
+        1. Run `uv run cairn dispatch --config dispatch.yaml`
+        2. Create a project with origin "..." and goal "..."
+        3. Observe error in dispatcher logs
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs / Error Output / 日志 / 错误输出"
+      description: "Paste relevant logs or error messages. / 粘贴相关日志或错误信息。"
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment / 环境信息"
+      description: "Please provide your environment details. / 请提供环境信息。"
+      value: |
+        - OS / 系统:
+        - Python version / Python 版本:
+        - Cairn version / Cairn 版本:
+        - Deploy method / 部署方式: [Docker Compose / Manual]
+        - Worker backend / Worker 后端: [Claude Code / Codex / Pi]
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: "Configuration / 配置（optional / 可选）"
+      description: "Relevant parts of dispatch.yaml (redact API keys). / dispatch.yaml 相关配置（请隐去 API 密钥）。"
+      render: yaml
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: "Additional Context / 补充信息（optional / 可选）"
+      description: "Screenshots, related issues, or anything else. / 截图、相关 issue 或其他信息。"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Question / Discussion / 提问 / 讨论"
+    url: https://github.com/oritera/Cairn/discussions
+    about: "Ask questions or start a discussion / 提问或发起讨论"
+  - name: "Discord"
+    url: https://discord.gg/nDSy4NZVP
+    about: "Chat with the community / 加入社区交流"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: "Feature Request / 功能建议"
+description: "Suggest a new feature or improvement / 提出新功能或改进建议"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We appreciate your ideas! Please describe what you'd like to see.
+        欢迎提出建议！请描述你希望看到的改进。
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Component / 组件"
+      description: "Which part of Cairn does this relate to? / 与 Cairn 的哪个部分相关？"
+      options:
+        - "Server (API / Web UI)"
+        - "Dispatcher (Scheduler / Tasks)"
+        - "Worker (Claude Code / Codex / Pi)"
+        - "Container / Docker"
+        - "New Worker Backend / 新 Worker 后端"
+        - "Documentation / 文档"
+        - "Other / 其他"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation / 动机"
+      description: "Why is this feature needed? What problem does it solve? / 为什么需要这个功能？它解决什么问题？"
+      placeholder: |
+        I'm trying to ... but currently ...
+        我尝试……但目前……
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Proposed Solution / 方案描述"
+      description: "Describe how you'd like it to work. / 描述你期望的工作方式。"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives Considered / 备选方案（optional / 可选）"
+      description: "Any alternatives you've thought about. / 你考虑过的其他方案。"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: "Additional Context / 补充信息（optional / 可选）"
+      description: "Mockups, references, or related issues. / 原型图、参考资料或相关 issue。"


### PR DESCRIPTION
## Summary

- Add **Bug Report** template with structured fields: component dropdown, description, reproduction steps, logs, environment info, configuration
- Add **Feature Request** template with: component dropdown, motivation, proposed solution, alternatives
- Add **config.yml** to disable blank issues and provide contact links (Discussions + Discord)
- All templates are bilingual (English / Chinese) — labels and descriptions side by side

## Files

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`

## Test plan

- [ ] Navigate to Issues → New Issue and verify template chooser appears
- [ ] Verify Bug Report form renders with all fields and Chinese/English labels
- [ ] Verify Feature Request form renders correctly
- [ ] Verify blank issue is disabled and contact links show